### PR TITLE
feat: adicionar comando para self-atribuir cargo de ajuda

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ MEMBER_CNT_STRING="👫  Server: {n}"
 
 # The id of the role to be added to every member that joins the server
 AUTO_ROLE=""
+
+# The id of the role given by the /ajuda command
+AJUDA_ROLE_ID=""

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,0 +1,37 @@
+import { REST, Routes } from "discord.js";
+import { config } from "dotenv";
+import * as ajudaCommand from "./discord/commands/ajuda";
+
+config();
+
+const token = process.env.DISCORD_TOKEN;
+const clientId = process.env.CLIENT_ID;
+const guildId = process.env.GUILD_ID;
+
+if (!token || !clientId || !guildId) {
+    console.error("⚠️ Faltam dados no teu ficheiro .env! Verifica se tens o Token, Client ID e Guild ID.");
+    process.exit(1);
+}
+
+const commands = [
+    ajudaCommand.data.toJSON()
+];
+
+const rest = new REST({ version: '10' }).setToken(token);
+
+async function deploy() {
+    try {
+        console.log(`A enviar ${commands.length} comando(s) para o teu servidor de testes...`);
+
+        await rest.put(
+            Routes.applicationGuildCommands(clientId!, guildId!),
+            { body: commands }
+        );
+
+        console.log("✅ Comandos registados com sucesso no Discord!");
+    } catch (error) {
+        console.error("❌ Houve um erro ao registar os comandos:", error);
+    }
+}
+
+deploy();

--- a/src/discord/commands/ajuda.ts
+++ b/src/discord/commands/ajuda.ts
@@ -1,0 +1,38 @@
+import { SlashCommandBuilder, CommandInteraction, GuildMember } from "discord.js";
+
+export const data = new SlashCommandBuilder()
+    .setName("ajuda")
+    .setDescription("Atribui ou remove o cargo de Ajuda Online.");
+export async function execute(interaction: CommandInteraction) {
+    const roleId = process.env.AJUDA_ROLE_ID; //ID do cargo
+
+    if (!roleId) {
+        await interaction.reply({ content: "Erro: O ID do cargo não está configurado no sistema!", ephemeral: true });
+        return;
+    }
+    
+    if (!interaction.guild || !(interaction.member instanceof GuildMember)) {
+        await interaction.reply({ content: "Este comando só pode ser usado num servidor.", ephemeral: true });
+        return;
+    }
+
+    const member = interaction.member;
+    const role = interaction.guild.roles.cache.get(roleId);
+
+    //Se o cargo não existir
+    if (!role) {
+        await interaction.reply({ content: "O cargo de ajuda não foi encontrado no servidor!", ephemeral: true });
+        return;
+    }
+
+    //Verifica se o membro já tem o cargo
+    if (member.roles.cache.has(roleId)) {
+        //Se tiver, remove o cargo
+        await member.roles.remove(roleId);
+        await interaction.reply({ content: "Cargo de Ajuda Online removido com sucesso!", ephemeral: true });
+    } else {
+        //Se não tiver, adiciona o cargo
+        await member.roles.add(roleId);
+        await interaction.reply({ content: "Cargo de Ajuda Online adicionado com sucesso!", ephemeral: true });
+    }
+}

--- a/src/discord/events/interactionCreate.ts
+++ b/src/discord/events/interactionCreate.ts
@@ -1,0 +1,17 @@
+import { Client, Interaction } from "discord.js";
+import * as ajudaCommand from "../commands/ajuda";
+
+export async function run(client: Client, interaction: Interaction) {
+    //Verifica se a interação é um comando de barra
+    if (!interaction.isChatInputCommand()) return;
+
+    //Executa se for o "Ajuda"
+    if (interaction.commandName === "ajuda") {
+        try {
+            await ajudaCommand.execute(interaction);
+        } catch (error) {
+            console.error(error);
+            await interaction.reply({ content: 'Houve um erro ao executar o comando!', ephemeral: true });
+        }
+    }
+}


### PR DESCRIPTION
Adiciona o comando "/ajuda" que permite aos membros atribuírem ou removerem a si próprios o cargo de ajuda online.

Detalhes:
- Adicionado ficheiro do comando em "src/discord/commands/ajuda.ts".
- Adicionado ID do cargo como variável de ambiente para ser configurável.
- Atualizado o ficheiro ".env.example" com a variável "AJUDA_ROLE_ID".