### PR TITLE
feat: adicionar comando /projeto para criação de canais e cargos

### DIFF
--- a/src/discord/ProjectManager.ts
+++ b/src/discord/ProjectManager.ts
@@ -1,0 +1,55 @@
+import { Guild, ChannelType, PermissionsBitField, Role, CategoryChannel } from 'discord.js';
+
+/**
+ * @param guild O servidor do Discord onde os elementos serão criados.
+ * @param projectName O nome do projeto.
+ */
+export async function createProject(guild: Guild, projectName: string): Promise<{ success: boolean; role?: Role; category?: CategoryChannel; error?: any }> {
+    try {
+        // 1. Criar o Cargo para o Projeto
+        const projectRole = await guild.roles.create({
+            name: projectName,
+            color: 'Random', // Podes alterar para uma cor hexadecimal em string, ex: '#FF5733'
+            reason: `Cargo gerado automaticamente para o projeto: ${projectName}`,
+        });
+
+        // 2. Criar a Categoria Privada (Visível apenas para o novo cargo e admins)
+        const projectCategory = await guild.channels.create({
+            name: `📁 ${projectName}`,
+            type: ChannelType.GuildCategory,
+            permissionOverwrites: [
+                {
+                    id: guild.id, // O ID do servidor equivale ao cargo @everyone
+                    deny: [PermissionsBitField.Flags.ViewChannel],
+                },
+                {
+                    id: projectRole.id, // O ID do novo cargo do projeto
+                    allow: [PermissionsBitField.Flags.ViewChannel],
+                },
+            ],
+            reason: `Categoria gerada para o projeto: ${projectName}`,
+        });
+
+        // 3. Criar o Canal de Texto dentro da categoria
+        // Formatamos o nome para letras minúsculas e substituímos espaços por hífens
+        const textChannelName = `💬-geral-${projectName.toLowerCase().replace(/\s+/g, '-')}`;
+        await guild.channels.create({
+            name: textChannelName,
+            type: ChannelType.GuildText,
+            parent: projectCategory.id, // Coloca o canal dentro da categoria criada
+        });
+
+        // 4. Criar o Canal de Voz dentro da categoria
+        await guild.channels.create({
+            name: `🔊 Reuniões`,
+            type: ChannelType.GuildVoice,
+            parent: projectCategory.id,
+        });
+
+        return { success: true, role: projectRole, category: projectCategory };
+
+    } catch (error) {
+        console.error(`[ProjectManager] Erro ao criar a estrutura do projeto ${projectName}:`, error);
+        return { success: false, error };
+    }
+}

--- a/src/discord/events/interactionCreate.ts
+++ b/src/discord/events/interactionCreate.ts
@@ -1,0 +1,45 @@
+import { Interaction } from "discord.js";
+import { createProject } from "../ProjectManager"; 
+import Logger from "../../Logger";
+
+export async function run(...args: any[]) {
+    const interaction = args.find(arg => arg && typeof arg.isChatInputCommand === 'function') as Interaction;
+
+    if (!interaction || !interaction.isChatInputCommand()) return;
+
+    if (interaction.commandName === 'projeto') {
+        const projectName = interaction.options.getString('nome', true);
+        const guild = interaction.guild;
+
+        if (!guild) {
+            await interaction.reply({ content: '❌ Este comando só pode ser usado dentro de um servidor.', ephemeral: true });
+            return;
+        }
+
+        try {
+            await interaction.reply({ content: `⏳ A criar a estrutura do projeto **${projectName}**... Por favor aguarda.`, ephemeral: true });
+
+            // Executar a função do ProjectManager para criar os canais e cargo
+            const result = await createProject(guild, projectName);
+
+            if (result.success && result.role) {
+                // Dar o cargo a quem executou o comando
+                try {
+                    const member = await guild.members.fetch(interaction.user.id);
+                    await member.roles.add(result.role);
+                } catch (roleError) {
+                    Logger.log(`Aviso: Projeto criado, mas falhou ao dar o cargo ao utilizador: ${roleError}`);
+                }
+
+                // Atualizar a mensagem final
+                await interaction.editReply(`✅ O projeto **${projectName}** foi criado com sucesso! Foste adicionado ao projeto com o cargo <@&${result.role.id}>.`);
+                Logger.log(`Projeto '${projectName}' criado com sucesso por ${interaction.user.tag}`);
+            } else {
+                await interaction.editReply(`❌ Ocorreu um erro ao criar o projeto. Garante que o meu cargo está acima dos cargos normais e que tenho permissões de Administrador.`);
+                Logger.log(`Erro ao criar projeto '${projectName}': ${result.error}`);
+            }
+        } catch (error) {
+            Logger.log(`Erro ao executar o comando /projeto: ${error}`);
+        }
+    }
+}

--- a/src/discord/events/ready.ts
+++ b/src/discord/events/ready.ts
@@ -1,11 +1,36 @@
-import { ActivityType, Client } from "discord.js";
+import { ActivityType, Client, SlashCommandBuilder } from "discord.js";
 import Logger from "../../Logger";
 import { MemberCounterHelper } from "../MemberCountHelper";
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 export async function run(client: Client) {
     client.user?.setPresence({ activities: [{ name: "SuperTux", type: ActivityType.Playing }] });
-    
+
     Logger.log(`Bot Ready! Logged in as ${client.user?.tag ?? "unknown"}`);
 
     new MemberCounterHelper(client).start();
+
+    const projectCommand = new SlashCommandBuilder()
+        .setName('projeto')
+        .setDescription('Cria canais e um cargo para um novo projeto.')
+        .addStringOption(option => 
+            option.setName('nome')
+                .setDescription('O nome do projeto que queres criar')
+                .setRequired(true)
+        );
+
+    try {
+        const guildId = process.env.GUILD_ID;
+        
+        if (guildId) {
+            const guild = await client.guilds.fetch(guildId);
+            await guild.commands.create(projectCommand);
+        } else {
+            await client.application?.commands.create(projectCommand);
+        }
+    } catch (error) {
+        Logger.log(`❌ Erro ao registar o comando /projeto: ${error}`);
+    }
 }


### PR DESCRIPTION
Este Pull Request introduz o novo comando `/projeto`, que automatiza a criação de toda a estrutura necessária para iniciar um novo projeto no servidor. 

## 🛠️ Alterações Realizadas
* **`ProjectManager.ts`:** Criada a função principal `createProject` que interage com a API do Discord para criar:
  * Um novo cargo com o nome do projeto (cor aleatória).
  * Uma Categoria privada (ViewChannel bloqueado para o `@everyone` e permitido para o novo cargo).
  * Um canal de texto `💬-geral-[nome-do-projeto]` e um canal de voz `🔊 Reuniões` associados à categoria.
* **`ready.ts`:** Adicionado o registo do *Slash Command* na inicialização do bot (com suporte a `GUILD_ID` via `.env` para registo instantâneo em modo de desenvolvimento).
* **`interactionCreate.ts`:** Implementado o *handler* inteligente com `...args` para ler o input do comando, executar o `ProjectManager`, e atribuir automaticamente o cargo recém-criado ao utilizador que invocou o comando.

## 🧪 Como Testar
1. Garantir que o `GUILD_ID` e o `DISCORD_TOKEN` estão corretos no `.env`.
2. Iniciar o bot 
3. No servidor do Discord, executar o comando `/projeto nome: [Nome do Teste]`.
4. Verificar se a categoria, os canais e o cargo são criados corretamente.
5. Confirmar se o cargo foi atribuído ao teu próprio utilizador de forma automática.